### PR TITLE
[Proposal] Prototype to introduce optional `immutableMode`

### DIFF
--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -221,6 +221,7 @@ export interface SetOptionOpts {
     // other components of the certain `mainType` will be removed.
     replaceMerge?: GlobalModelSetOptionOpts['replaceMerge'];
     transition?: SetOptionTransitionOpt
+    immutableMode?: boolean;
 };
 
 export interface ResizeOpts {
@@ -605,10 +606,15 @@ class ECharts extends Eventful<ECEventDefinition> {
      * @param opts.replaceMerge Default undefined.
      */
     // Expose to user full option.
-    setOption<Opt extends ECBasicOption>(option: Opt, notMerge?: boolean, lazyUpdate?: boolean): void;
+    setOption<Opt extends ECBasicOption>(
+        option: Opt,
+        notMerge?: boolean,
+        lazyUpdate?: boolean,
+        immutableMode?: boolean
+      ): void;
     setOption<Opt extends ECBasicOption>(option: Opt, opts?: SetOptionOpts): void;
     /* eslint-disable-next-line */
-    setOption<Opt extends ECBasicOption>(option: Opt, notMerge?: boolean | SetOptionOpts, lazyUpdate?: boolean): void {
+    setOption<Opt extends ECBasicOption>(option: Opt, notMerge?: boolean | SetOptionOpts, lazyUpdate?: boolean, immutableMode?: boolean): void {
         if (this[IN_MAIN_PROCESS_KEY]) {
             if (__DEV__) {
                 error('`setOption` should not be called during main process.');
@@ -643,7 +649,7 @@ class ECharts extends Eventful<ECEventDefinition> {
             ecModel.init(null, null, null, theme, this._locale, optionManager);
         }
 
-        this._model.setOption(option as ECBasicOption, { replaceMerge }, optionPreprocessorFuncs);
+        this._model.setOption(option as ECBasicOption, { replaceMerge, immutableMode }, optionPreprocessorFuncs);
 
         const updateParams = {
             seriesTransition: transitionOpt,

--- a/src/core/echarts.ts
+++ b/src/core/echarts.ts
@@ -635,6 +635,7 @@ class ECharts extends Eventful<ECEventDefinition> {
             silent = notMerge.silent;
             replaceMerge = notMerge.replaceMerge;
             transitionOpt = notMerge.transition;
+            immutableMode = notMerge.immutableMode;
             notMerge = notMerge.notMerge;
         }
 

--- a/src/data/DataStore.ts
+++ b/src/data/DataStore.ts
@@ -178,17 +178,11 @@ class DataStore {
 
     private _calcDimNameToIdx = createHashMap<DimensionIndex, DimensionName>();
 
-    // TODO (immutableMode): make immutableMode configurable
+    // TODO (immutableMode): make immutableMode configurable, similar to option params replaceMerge, notMerge, lazyUpdate
+    // - https://echarts.apache.org/en/api.html#echartsInstance.setOption
     private immutableMode = true;
 
     defaultDimValueGetter: DimValueGetter;
-
-    /**
-     * Setter for immutableMode to bypass cloning logic
-     */
-    setImmutableMode(mode: boolean): void {
-        this.immutableMode = mode;
-    }
 
     /**
      * Initialize from data
@@ -206,10 +200,6 @@ class DataStore {
         }
 
         this._provider = provider;
-
-        // TODO (immutableMode): remove after immutableMode is configurable, similar to option params replaceMerge, notMerge, lazyUpdate
-        // - https://echarts.apache.org/en/api.html#echartsInstance.setOption
-        this.setImmutableMode(true);
 
         // Clear
         this._chunks = [];

--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -65,6 +65,7 @@ import { error, warn } from '../util/log';
 
 export interface GlobalModelSetOptionOpts {
     replaceMerge: ComponentMainType | ComponentMainType[];
+    immutableMode?: boolean;
 }
 export interface InnerSetOptionOpts {
     replaceMergeMainTypeMap: HashMap<boolean, string>;
@@ -1075,6 +1076,12 @@ function normalizeSetOptionInput(opts: GlobalModelSetOptionOpts): InnerSetOption
         }
         replaceMergeMainTypeMap.set(mainType, true);
     });
+
+    // Pass immutableMode to opt out of cloning
+    if (opts.immutableMode) {
+      replaceMergeMainTypeMap.set('immutableMode', true);
+    }
+
     return {
         replaceMergeMainTypeMap: replaceMergeMainTypeMap
     };

--- a/src/model/Global.ts
+++ b/src/model/Global.ts
@@ -1078,7 +1078,7 @@ function normalizeSetOptionInput(opts: GlobalModelSetOptionOpts): InnerSetOption
     });
 
     // Pass immutableMode to opt out of cloning
-    if (opts.immutableMode) {
+    if (opts && opts.immutableMode) {
       replaceMergeMainTypeMap.set('immutableMode', true);
     }
 

--- a/src/model/OptionManager.ts
+++ b/src/model/OptionManager.ts
@@ -108,7 +108,11 @@ class OptionManager {
         // Caution: some series modify option data, if do not clone,
         // it should ensure that the repeat modify correctly
         // (create a new object when modify itself).
-        rawOption = clone(rawOption);
+        // Use immutableMode option to opt out of cloning.
+        const immutableMode = opt.replaceMergeMainTypeMap.data.get('immutableMode') ?? false;
+        if (!immutableMode) {
+          rawOption = clone(rawOption);
+        }
 
         // FIXME
         // If some property is set in timeline options or media option but

--- a/src/model/OptionManager.ts
+++ b/src/model/OptionManager.ts
@@ -95,6 +95,8 @@ class OptionManager {
         optionPreprocessorFuncs: OptionPreprocessor[],
         opt: InnerSetOptionOpts
     ): void {
+        // eslint-disable-next-line
+        console.log('(OptionManager) - setOption -> opt: ', opt);
         if (rawOption) {
             // That set dat primitive is dangerous if user reuse the data when setOption again.
             each(normalizeToArray((rawOption as ECUnitOption).series), function (series: SeriesOption) {
@@ -111,7 +113,13 @@ class OptionManager {
         // Use immutableMode option to opt out of cloning.
         const immutableMode = opt.replaceMergeMainTypeMap.data.get('immutableMode') ?? false;
         if (!immutableMode) {
-          rawOption = clone(rawOption);
+            // eslint-disable-next-line
+            console.log('(OptionManager) - CLONED rawOption: ', rawOption);
+            rawOption = clone(rawOption);
+        }
+        else {
+            // eslint-disable-next-line
+            console.log('(OptionManager) - BYPASSED clone rawOption: ', rawOption);
         }
 
         // FIXME

--- a/test/option-immutableMode.html
+++ b/test/option-immutableMode.html
@@ -92,7 +92,7 @@ under the License.
             var chart = testHelper.create(echarts, 'main_immutableMode_obj_true', {
                 title: [
                     'immutableMode: true',
-                    'click "setOption": "bb" become bar chart, "aa" become **rect** symbol',
+                    'click "setOption": "TODO: add immutableMode test case"',
                     'other series **do not change**'
                 ],
                 option: option,
@@ -145,7 +145,8 @@ under the License.
             var chart = testHelper.create(echarts, 'main_immutableMode_param', {
                 title: [
                     'immutableMode: true',
-                    'click "setOption": "aa" become **rect** symbol, "no_id" become "new_no_id" and bar',
+                    'click "setOption": "TODO: add immutableMode test case"',
+                    // 'click "setOption": "aa" become **rect** symbol, "no_id" become "new_no_id" and bar',
                     'other series **do not change**'
                 ],
                 option: option,

--- a/test/option-immutableMode.html
+++ b/test/option-immutableMode.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/simpleRequire.js"></script>
+        <script src="lib/config.js"></script>
+        <script src="lib/jquery.min.js"></script>
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/testHelper.js"></script>
+        <!-- <script src="ut/lib/canteen.js"></script> -->
+        <link rel="stylesheet" href="lib/reset.css" />
+    </head>
+    <body>
+        <style>
+        </style>
+
+
+        <div id="main_immutableMode_obj_true"></div>
+        <div id="main_immutableMode_param"></div>
+ 
+        <script>
+            function makeBasicOption(opt) {
+                return {
+                    xAxis: {
+                        type: 'category'
+                    },
+                    yAxis: {},
+                    legend: {},
+                    tooltip: {},
+                    dataZoom: [{
+                        type: 'slider'
+                    }, {
+                        type: 'inside'
+                    }],
+                    series: [{
+                        id: 'a',
+                        name: 'aa',
+                        type: 'line',
+                        data: [['a11', 22], ['a33', 44]]
+                    }, {
+                        id: 'b',
+                        name: 'bb',
+                        type: 'line',
+                        data: [['a11', 55], ['a33', 77]]
+                    }, {
+                        id: 'c',
+                        name: 'cc',
+                        type: 'line',
+                        data: [['a11', 66], ['a33', 100]]
+                    }, {
+                        id: 'd',
+                        name: 'dd',
+                        type: 'line',
+                        data: [['a11', 99], ['a33', 130]]
+                    }, {
+                        name: 'no_id',
+                        type: 'line',
+                        data: [['a11', 130], ['a33', 160]]
+                    }]
+                };
+            }
+        </script>
+
+
+        <script>
+        require(['echarts'], function (echarts) {
+            const option = makeBasicOption();
+
+            const opts =  { notMerge: true, lazyUpdate: false, immutableMode: true };
+
+            var chart = testHelper.create(echarts, 'main_immutableMode_obj_true', {
+                title: [
+                    'immutableMode: true',
+                    'click "setOption": "bb" become bar chart, "aa" become **rect** symbol',
+                    'other series **do not change**'
+                ],
+                option: option,
+                buttons: [{
+                    text: 'setOption',
+                    onclick: function () {
+                        chart.setOption(option, true, false, true )
+                        // chart.setOption(option, { notMerge: true, lazyUpdate: false, immutableMode: true } ) // TODO: why does this not get forwarded to GlobalModel setOption?
+                    }
+                    // onclick: function () {
+                    //     chart.setOption(option, { opts: { notMerge: true, lazyUpdate: false, immutableMode: true } } )
+                    // }
+                    //
+                    // onclick: function () {
+                    //     chart.setOption({
+                    //         series: [{
+                    //             id: 'b',
+                    //             type: 'bar',
+                    //             data: [['a11', 55], ['a33', 77]]
+                    //         }, {
+                    //             id: 'a',
+                    //             symbol: 'rect'
+                    //         }]
+                    //     }, { notMerge: true, lazyUpdate: false, immutableMode: true } )
+                    // } 
+                    //
+                    // onclick: function () {
+                    //     chart.setOption({
+                    //         series: [{
+                    //             id: 'b',
+                    //             type: 'bar',
+                    //             data: [['a11', 55], ['a33', 77]]
+                    //         }, {
+                    //             id: 'a',
+                    //             symbol: 'rect'
+                    //         }]
+                    //     }, true, false, true )
+                    // }
+                }],
+                height: 300
+            });
+        });
+        </script>
+
+
+        <script>
+        require(['echarts'], function (echarts) {
+            var option = makeBasicOption();
+
+            var chart = testHelper.create(echarts, 'main_immutableMode_param', {
+                title: [
+                    'immutableMode: true',
+                    'click "setOption": "aa" become **rect** symbol, "no_id" become "new_no_id" and bar',
+                    'other series **do not change**'
+                ],
+                option: option,
+                buttons: [{
+                    text: 'setOption',
+                    onclick: function () {
+                        chart.setOption(option, true, false, true)
+                    }
+                }],
+                height: 300
+            });
+        });
+        </script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
## Overview

With large datasets deep cloning is expensive and can harm performance. When using ECharts with certain UI libraries like React, immutable data is a best practice, meaning when setOption is called, additional checks and safeguards that relying on deep cloning data might be unnecessary.

Currently OptionManager and DataStore handle calling clone utils and there is no way to opt out. This branch proposes a potential solution by exposing a new immutableMode property within setOption params. This property is optional and defaults to false, but when set calls to `clone(rawOption)` (as well as potentially cloneChild / clone indices) will be bypassed. This will most likely require extensive refactoring but the lift in each individual series type is TBD.

## Open Questions

- Do charts mutate data, if so, which ones and how much work to update them?
  - Early testing and certain comments in code make me hopeful, see line [here](https://github.com/apache/echarts/blob/5.4.3/src/data/DataStore.ts#L157) `"DataStore API keep immutable."`
  - EDIT: Comments like [this one](https://github.com/apache/echarts/blob/6b8fae82eb5fbd1042b6262dd6b5d39d9adbf373/src/model/OptionManager.ts#L108-L111), make me nervous. "some series modify option data"
    - Does this include 'line' series, with 'time' axis specifically? Seems like we're safe there and since immutableMode is opt-in, maybe it's okay to proceed with documentation that warns users

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others

### What does this PR do?

Introduces an optional `immutableMode` property to setOption, aimed at optimizing performance for large datasets, where the chart needs to re-render frequently.

### Details

- Introduce an `immutableMode` property to setOption params, this flag is optional and defaults to false (preserves existing behavior for backward compatibility)
- When enabled, `immutableMode` bypasses the calls to `clone(rawOption)` in OptionManager.ts -> setOption method
- Also added pseudo-code for bypassing `cloneChunk` and `_cloneIndices` in DataStore.ts
  - TODO: how to initialize immutableMode in DataStore correctly, should these changes be handled separately?
- Lots more refactoring and testing needed to see if this is even a viable direction